### PR TITLE
Fix Events Without Backing Fields

### DIFF
--- a/APublicizer.cs
+++ b/APublicizer.cs
@@ -209,15 +209,8 @@ namespace APublicizer
 
         private void DoFixupEvents(PublicizeResult value)
         {
-            bool FilterEvent(EventDefinition e)
-            {
-                // It'll cause a compilation error if I don't do
-                e.DeclaringType.Fields.Single(f => f.Name == e.Name).IsPublic = false;
-                // Don't lie to users
-                value.Fields--;
-
-                return e.AddMethod.IsPrivate || e.RemoveMethod.IsPrivate || (e.InvokeMethod?.IsPrivate ?? false);
-            }
+            bool FilterEvent(EventDefinition e) =>
+                e.AddMethod.IsPrivate || e.RemoveMethod.IsPrivate || (e.InvokeMethod?.IsPrivate ?? false);
 
             void ProcessEvent(EventDefinition e)
             {

--- a/APublicizer.cs
+++ b/APublicizer.cs
@@ -209,8 +209,19 @@ namespace APublicizer
 
         private void DoFixupEvents(PublicizeResult value)
         {
-            bool FilterEvent(EventDefinition e) =>
-                e.AddMethod.IsPrivate || e.RemoveMethod.IsPrivate || (e.InvokeMethod?.IsPrivate ?? false);
+            bool FilterEvent(EventDefinition e)
+            {
+                // Sometimes, for some reason, events have the same name as their backing fields.
+                // If both are public, neither can be accessed (name conflict).
+                var backing = e.DeclaringType.Fields.SingleOrDefault(f => f.Name == e.Name);
+                if (backing != null)
+                {
+                    backing.IsPublic = false;
+                    value.Fields--;
+                }
+
+                return e.AddMethod.IsPrivate || e.RemoveMethod.IsPrivate || (e.InvokeMethod?.IsPrivate ?? false);
+            }
 
             void ProcessEvent(EventDefinition e)
             {


### PR DESCRIPTION
The current code assumes that there is a backing field for all events. This is not necessarily true for custom add/remove accessors. *Hot Dogs, Horseshoes & Hand Grenades* (H3VR) has both custom and standard accessors, and causes the following exception:
```
Unhandled exception. System.InvalidOperationException: Sequence contains no matching element
   at System.Linq.ThrowHelper.ThrowNoMatchException()
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source, Func`2 predicate)
   at APublicizer.Publicizer.<>c__DisplayClass16_0.<DoFixupEvents>g__FilterEvent|0(EventDefinition e) in F:\Development\csharp\project\APublicizer\APublicizer.cs:line 215
   at APublicizer.Publicizer.Processor[T](Collection`1 values, Predicate`1 filter, Action`1 processor, Action bump) in F:\Development\csharp\project\APublicizer\APublicizer.cs:line 144
   at APublicizer.Publicizer.<>c__DisplayClass16_0.<DoFixupEvents>b__3(Collection`1 es) in F:\Development\csharp\project\APublicizer\APublicizer.cs:line 233
   at APublicizer.Publicizer.ArrayProcessor[T,R](Collection`1 values, Func`2 getter, Action`1 processor) in F:\Development\csharp\project\APublicizer\APublicizer.cs:line 158
   at APublicizer.Publicizer.DoFixupEvents(PublicizeResult value) in F:\Development\csharp\project\APublicizer\APublicizer.cs:line 231
   at APublicizer.Publicizer.DoPublicize(PublicizeResult value) in F:\Development\csharp\project\APublicizer\APublicizer.cs:line 108
   at APublicizer.Publicizer.Run() in F:\Development\csharp\project\APublicizer\APublicizer.cs:line 95
   at APublicizer.APublicizer.Main(String[] args) in F:\Development\csharp\project\APublicizer\APublicizer.cs:line 17
```

With the edits I have made, I can publicize H3VR. I have not tested other games.